### PR TITLE
Feature/add translations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ It should look like this:
 ```ini
 GOOGLE_API_KEY=...
 GOOGLE_SHEET_ID=...
-DEFAULT_CATEGORY_COMBO_ID=...
 DHIS2_BASE_URL=...
 DHIS2_USERNAME=...
 DHIS2_PASSWORD=...
@@ -49,21 +48,6 @@ can use the `Data Administration` app, go to `Maintenance`, select
 `Update category option combinations` and click on the
 `Perform Maintenance` button. Alternatively, you can just set in the
 `.env.local` file the `UPDATE_CATEGORY_OPTION_COMBOS` option to `true`.
-
-## Default category combo
-
-To get the default `categoryCombo` used at a dhis2 instance, go to the
-following endpoint:
-`/api/categoryCombos.json?filter=name:eq:default&fields=id,name` .
-
-### How the default category combo is used
-
-If you want to understand what is special about the default category
-combination and how it works in dhis2, you can check [this talk by Jim
-Grace](https://youtu.be/EcR9QwJvc7c?t=314) (and maybe [these
-slides](https://drive.google.com/file/d/1MWq-Nx-AcSSuTfF9z7VPq0W9PXyl9IAn/view)).
-
-It is used at least in `dataElements`, `dataSets`, and `programs`.
 
 ## Accessing google spreadsheets
 

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -22,7 +22,7 @@ async function main() {
     const sheets = data.sheets?.filter(sheet => sheet.properties?.title != "DHIS2").map(loadSheet) ?? [];
 
     log("Converting to metadata...");
-    const metadata = buildMetadata(sheets, env.DEFAULT_CATEGORY_COMBO_ID ?? "");
+    const metadata = buildMetadata(sheets);
 
     log("Writing it to out.json ...");
     fs.writeFileSync("out.json", JSON.stringify(metadata, null, 4));

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -35,7 +35,7 @@ type localeKey =
 
 // Return an object containing the metadata representation of all the sheets
 // that are included in the spreadsheet.
-export function buildMetadata(sheets: Sheet[], defaultCC: string) {
+export function buildMetadata(sheets: Sheet[]) {
     const get = (name: string) => getItems(sheets, name); // shortcut
 
     const sheetDataSets = get("dataSets"),


### PR DESCRIPTION
### :pushpin: References

**Issue:**  [Add translations support (in particular data elements): new excel tab with 4 fields (name/id, property, language, value)](https://app.clickup.com/t/3h1umt4)

### :memo: Implementation

This branch implements: 
- A generic translation function that will work with `${metadataType}Translations` tabs
- New spreadsheet tabs: 
  - dataSetTranslations: Columns: [dataSet | name | locale | value]. The field name is for property name.
  - dataElementTranslations: Columns: [dataElement | name | locale | value]. The field name is for property name.
  - programDataElementTranslations: Columns: [programDataElement | name | locale | value]. The field name is for property name.
  - categoryTranslations: Columns: [category | name | locale | value]. The field name is for property name.
  - categoryOptionTranslations: Columns: [categoryOption | name | locale | value]. The field name is for property name.
  - dataElementGroupTranslations: Columns: [dataElementGroup | name | locale | value]. The field name is for property name.
  - dataElementGroupSetTranslations: Columns: [dataElementGroupSet | name | locale | value]. The field name is for property name.
  - trackedEntityTypeTranslations: Columns: [trackedEntityType | name | locale | value]. The field name is for property name.
  - trackedEntityAttributeTranslations: Columns: [trackedEntityAttribute | name | locale | value]. The field name is for property name.
  - programTranslations: Columns: [program | name | locale | value]. The field name is for property name.
  - programStageTranslations: Columns: [programStage | name | locale | value]. The field name is for property name.
  - optionSetTranslations: Columns: [optionSet | name | locale | value]. The field name is for property name.
  - sectionTranslations: Columns: [section | name | locale | value]. The field name is for property name.
  - programRuleTranslations: Columns: [programRule | name | locale | value]. The field name is for property name.
  - programRuleVariableTranslations: Columns: [programRuleVariable | name | locale | value]. The field name is for property name.


### :fire: Notes to the tester
- Table with elements that can have translations: https://docs.dhis2.org/en/full/develop/dhis-core-version-238/developer-manual.html#webapi_translations
- Minimal translations implemented: dataSet, dataElements/programDataElements, category, categoryCombo y categoryOptions.