### PR TITLE
add sharing settings for optionsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ cypress/fixtures/
 .idea/*
 
 out.json
+/dist

--- a/src/domain/entities/DataElement.ts
+++ b/src/domain/entities/DataElement.ts
@@ -11,7 +11,9 @@ export interface DataElement {
     aggregationType: AggregationType;
     domainType: DomainType;
     description: string;
-    optionSet: string;
+    optionSet: {
+        id: Id;
+    };
     commentOptionSet: string;
     zeroIsSignificant: boolean;
     url: string;

--- a/src/domain/usecases/BuildMetadataUseCase.ts
+++ b/src/domain/usecases/BuildMetadataUseCase.ts
@@ -62,10 +62,11 @@ export class BuildMetadataUseCase {
 
         const options = _(sheetOptions)
             .map(option => {
-                const optionSet = sheetOptionSets.find(({ name }) => name === option.optionSet)?.id;
-                this.addSharingSetting(optionSet);
-
-                return { ...option, optionSet: { id: optionSet } };
+                const optionSet = sheetOptionSets.find(({ name }) => name === option.optionSet);
+                if (optionSet) {
+                    this.addSharingSetting(optionSet);
+                }
+                return { ...option, optionSet: { id: optionSet?.id } };
             })
             .groupBy(({ optionSet }) => optionSet.id)
             .mapValues(options => options.map((option, index) => ({ ...option, sortOrder: index + 1 })))

--- a/src/domain/usecases/PullDataSetUseCase.ts
+++ b/src/domain/usecases/PullDataSetUseCase.ts
@@ -196,7 +196,7 @@ export class PullDataSetUseCase {
             aggregationType: dataElement.aggregationType,
             domainType: dataElement.domainType,
             description: dataElement.description,
-            optionSet: dataElement.optionSet,
+            optionSet: dataElement.optionSet.id,
             commentOptionSet: dataElement.commentOptionSet,
             zeroIsSignificant: this.booleanToString(dataElement.zeroIsSignificant),
             url: dataElement.url,

--- a/src/domain/usecases/PullEventProgramUseCase.ts
+++ b/src/domain/usecases/PullEventProgramUseCase.ts
@@ -578,7 +578,7 @@ export class PullEventProgramUseCase {
             aggregationType: dataElement.aggregationType,
             domainType: dataElement.domainType,
             description: dataElement.description,
-            optionSet: dataElement.optionSet,
+            optionSet: dataElement.optionSet.id,
             commentOptionSet: dataElement.commentOptionSet,
             zeroIsSignificant: this.booleanToString(dataElement.zeroIsSignificant),
             url: dataElement.url,

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eyeseetea/d2-api@1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.9.2.tgz#a06bef44199b1e7031d1bb74d50bd3223d745b2a"
-  integrity sha512-O0NtSIse8ZimyA7kbjS+/D3M/ZeEA6nvW1DYaiXnG8hF7vQ15+d2Y4JuFunbg9mdo3KVcZLPPS8NAGi6rsKLWw==
+"@eyeseetea/d2-api@^1.13.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.14.0.tgz#546398b00b9f01b60a72ecba648a35f57b6f7559"
+  integrity sha512-gVNXfK8sk1STuM8QDed0JY8DM63SwI3UJXeKsyzJjHtPIqi76ukdCYAo8XwtfqhGdZIwIMrrWPEOmAJ3dbvCKQ==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@dhis2/d2-i18n" "^1.0.5"
@@ -54,6 +54,7 @@
     d2 "^31.8.1"
     dotenv "^8.0.0"
     express "^4.17.1"
+    form-data "^4.0.0"
     iconv-lite "0.6.2"
     isomorphic-fetch "3.0.0"
     lodash "^4.17.15"
@@ -452,6 +453,11 @@ async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 axios-debug-log@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/axios-debug-log/-/axios-debug-log-0.6.2.tgz#c7761ced8f1990e6d48c556b517af8e00edcef31"
@@ -626,6 +632,13 @@ colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -753,6 +766,11 @@ define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -995,6 +1013,15 @@ follow-redirects@1.5.10:
   integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -1474,7 +1501,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27:
+mime-types@^2.1.12, mime-types@^2.1.27:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/862kn23gz

### :memo: Implementation

Assign sharing settings to the option set object instead the id to avoid error:

```
Instead set sharing settings to the option set object it was being assigned to the 
```

### :art: Screenshots

### :fire: Notes to the tester

This bug was related specifically to importing `optionSets` and `options`.